### PR TITLE
feat: add TWZRD Agent Intel to agent trust & identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,10 @@ High-quality community fine-tunes built on Mistral base models:
 - 🌍 [Outlines](https://github.com/outlines-dev/outlines) ⭐ 10k+ – Guaranteed structured generation.
 - 🌍 [Marvin](https://github.com/prefecthq/marvin) – AI functions with type hints.
 
+### Agent Trust & Identity
+
+- 🌍 [TWZRD Agent Intel](https://intel.twzrd.xyz) – Trust scoring and wallet identity verification for Mistral-powered agents on Solana before x402 micropayments. Free MCP: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`
+
 ---
 
 ## Tooling & Dev Experience


### PR DESCRIPTION
## What

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the Agents & Orchestration section under a new "Agent Trust & Identity" subsection.

## Why

As Mistral-powered multi-agent pipelines become more common, agents need to verify the wallet identity and reputation of counterpart agents before authorizing x402 micropayments or granting access to paid APIs. TWZRD Agent Intel provides this missing trust layer on Solana.

**Tools:**
- `score_agent` — reputation score for a Solana agent wallet (free)
- `preflight_check` — pre-payment risk check (free)
- `get_trust_receipt` — signed trust receipt (paid x402 micropayment)

**Free MCP:**
```json
{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}
```

Service: https://intel.twzrd.xyz