### PR TITLE
Add Superhighway web search guide to Function Calling section

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ High-quality community fine-tunes built on Mistral base models:
 - 🌍 [Instructor](https://github.com/567-labs/instructor) ⭐ 13k+ – Structured outputs with Pydantic.
 - 🌍 [Outlines](https://github.com/dottxt-ai/outlines) ⭐ 13k+ – Guaranteed structured generation.
 - 🌍 [Marvin](https://github.com/prefecthq/marvin) – AI functions with type hints.
+- 🌍 [Superhighway](https://superhighway.walls.sh/guides/web-search-mistral) – Guide: add live web search to a Mistral app with function calling. Free API key or pay-per-call with USDC.
 
 ---
 


### PR DESCRIPTION
Adds a link to a guide for using Superhighway's web search API with Mistral's function calling.

The guide covers the full integration: define tools with the mistralai SDK, dispatch to Superhighway's /search, /news, and /scrape endpoints, agentic while-loop, and multi-tool dispatch. Free API key available at superhighway.walls.sh/pricing.