### PR TITLE
Add nika to Agent Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ High-quality community fine-tunes built on Mistral base models:
 - 🌍 [Semantic Kernel](https://github.com/microsoft/semantic-kernel) – Microsoft's AI orchestration SDK.
 - 🌍 [Haystack](https://github.com/deepset-ai/haystack) – End-to-end NLP framework.
 - 🌍 [PydanticAI](https://github.com/pydantic/pydantic-ai) – Type-safe AI agent framework.
+- 🌍 [nika](https://github.com/supernovae-st/nika) – Rust workflow engine where Mistral is a first-class named provider: `.nika.yaml` DAGs statically checked before execution, tamper-evident traces after.
 
 ### Function Calling & Structured Output
 


### PR DESCRIPTION
One line in Agents & Orchestration / Agent Frameworks (house format: globe emoji + en-dash + period). nika is an open-source (AGPL, Rust) workflow engine where Mistral is a first-class named provider (verified against the released binary: nika catalog lists mistral with MISTRAL_API_KEY; tasks address models as mistral/<model>) — and Mistral leads the cloud tier of its documented provider teaching order. Workflows are .nika.yaml DAGs statically checked before execution (schema, permits, cost floor) with tamper-evident traces after. Disclosure: I am the nika author (first-party submission).