### PR TITLE
docs: July 2026 ecosystem refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository maps and curates the entire Mistral.ai ecosystem for AI engineer
 
 ## Contents
 
-- [What's New (June 2026)](#whats-new-june-2026)
+- [What's New (July 2026)](#whats-new-july-2026)
 - [Why Mistral?](#why-mistral)
 - [Official Mistral Resources](#official-mistral-resources)
 - [Model Families](#model-families)
@@ -38,21 +38,19 @@ This repository maps and curates the entire Mistral.ai ecosystem for AI engineer
 
 ---
 
-## What's New (June 2026)
+## What's New (July 2026)
 
+- 🤝 **[Microsoft partnership expansion](https://news.microsoft.com/source/2026/07/21/microsoft-and-mistral-expand-strategic-partnership-to-give-enterprises-and-regulated-industries-frontier-ai-they-can-control/)** – Multibillion-dollar deal to expand European AI compute (NVIDIA Vera Rubin GPUs); Mistral Medium 3.5 and OCR 4 now available in Microsoft Foundry and Copilot Studio, with cloud, cloud-connected, and fully disconnected deployment options.
+- 🔖 **[Prompts & Skills versioning in Studio](https://mistral.ai/news/manage-prompts-and-skills-in-studio/)** – Immutable version history, ownership, and rollback for production prompts and MCP skills.
+- 🤖 **[Robostral Navigate](https://mistral.ai/news/robostral-navigate/)** – Mistral's first embodied-AI model: 8B parameters, single-RGB-camera navigation for wheeled, legged, and flying robots (proprietary, enterprise access).
+- 🧪 **[Leanstral 1.5](https://mistral.ai/news/leanstral-1-5/)** – Updated Lean 4 formal proof agent (Apache 2.0): saturates miniF2F, solves 587/672 PutnamBench problems, and found 5 real bugs across open-source repos.
+- 🔌 **[More control over connectors](https://mistral.ai/news/more-control-over-connectors/)** – Admin workspace controls, scoped API keys, and a connectors debugger for the 60+ Studio integrations.
+- 🔎 **[Mistral OCR 4](https://mistral.ai/news/ocr-4/)** – Document intelligence model with bounding boxes, block classification, and confidence scores across 170 languages ($4/1k pages, $2 with Batch API).
 - 🤖 **[Le Chat is now Vibe](https://mistral.ai/news/vibe-agent/)** – Mistral's assistant rebranded to **Vibe**, a unified agent with **Work**, **Code**, and **Chat** modes (web, mobile, CLI, and VS Code). Code sessions run in parallel, persist while your machine is off, and open PRs autonomously.
-- 🏛️ **[AI Now Summit 2026](https://mistral.ai/news/ai-now-summit-2026/)** – Inaugural Paris summit (28 May 2026): full-stack industrial AI strategy with Airbus, BMW Group, and ASML, plus a new inference data center in Essonne.
-- 🔬 **Physics AI** – Emmi AI joins Mistral, bringing physics-based simulation and real-time digital twins for engineering, aerospace, energy, and semiconductors.
-- 🔍 **Search Toolkit** – Production-grade search pipelines for grounded agent workflows.
-- 🔌 **Connectors in Studio** – Built-in and custom MCP connectors with direct tool calling and human-in-the-loop approvals.
 - 🚀 **[Mistral Medium 3.5](https://huggingface.co/mistralai/Mistral-Medium-3.5-128B)** – 128B dense flagship unifying reasoning, coding, and vision with 256k context (Modified MIT License); now the default model in Vibe. 77.6% SWE-bench Verified.
-- 🎙️ **[Voxtral TTS](https://huggingface.co/mistralai/Voxtral-4B-TTS-2603)** – 4B text-to-speech model across 9 languages (CC BY-NC 4.0).
 - 🚀 **[Mistral Small 4](https://huggingface.co/mistralai/Mistral-Small-4-119B-2603)** – Hybrid MoE (119B / 6.5B active) unifying reasoning, coding, and multimodal (Apache 2.0).
-- 🧪 **[Leanstral](https://huggingface.co/mistralai/Leanstral-2603)** – Open-source Lean 4 formal proof agent.
-- 🏢 **[Mistral Forge](https://mistral.ai/news/forge)** – Enterprise platform for training models on proprietary data.
+- 🎙️ **[Voxtral TTS](https://huggingface.co/mistralai/Voxtral-4B-TTS-2603)** – 4B text-to-speech model across 9 languages (CC BY-NC 4.0).
 - 🎙️ **[Voxtral Mini 4B Realtime](https://huggingface.co/mistralai/Voxtral-Mini-4B-Realtime-2602)** – Real-time speech-to-text with sub-500ms latency (13 languages, Apache 2.0).
-- 🛡️ **Mistral Moderation 2603** – Updated content moderation with jailbreaking detection.
-- 🖥️ **[Mistral Compute](https://mistral.ai/products/compute)** – European-hosted GPU cloud.
 
 ---
 
@@ -80,8 +78,8 @@ Mistral AI offers a compelling alternative in the LLM landscape:
 - 🧠 [Mistral Forge](https://mistral.ai/news/forge) – Enterprise platform for training frontier-grade models on proprietary data.
 - 🧠 [Mistral Compute](https://mistral.ai/products/compute) – European-hosted GPU cloud (NVIDIA Grace Blackwell).
 - 🧠 [Mistral AI GitHub](https://github.com/mistralai) – Official GitHub organization with 24+ repositories.
-- 🧠 [mistral-inference](https://github.com/mistralai/mistral-inference) ⭐ 11k+ – Official inference library for running Mistral models.
-- 🧠 [mistral-finetune](https://github.com/mistralai/mistral-finetune) ⭐ 3k+ – Official lightweight LoRA-based fine-tuning library.
+- 🧠 [mistral-inference](https://github.com/mistralai/mistral-inference) ⭐ 10k+ – ⚠️ Archived, no longer maintained – use [vLLM](https://github.com/vllm-project/vllm), [mistral.rs](https://github.com/EricLBuehler/mistral.rs), or the Mistral API instead.
+- 🧠 [mistral-finetune](https://github.com/mistralai/mistral-finetune) ⭐ 3k+ – ⚠️ Archived, no longer maintained – use [Axolotl](https://github.com/axolotl-ai-cloud/axolotl), [Unsloth](https://github.com/unslothai/unsloth), or Hugging Face [TRL](https://github.com/huggingface/trl) instead.
 - 🧠 [Mistral Cookbook](https://github.com/mistralai/cookbook) ⭐ 2k+ – Official notebooks and examples for common use cases.
 - 🧠 [mistral-common](https://github.com/mistralai/mistral-common) – Official tokenization and pre-processing library.
 - 🧠 [Mistral Vibe](https://github.com/mistralai/mistral-vibe) – Native CLI coding assistant featuring cloud-async Remote Agents and sandbox PR generation.
@@ -99,7 +97,7 @@ Mistral AI offers a compelling alternative in the LLM landscape:
 | **Mistral Large 3** | 256k | Apache 2.0 | Complex reasoning, multilingual, coding, vision (675B / 41B active) |
 | **Mistral Medium 3.5** | 256k | Modified MIT | Unified reasoning, coding, and vision (128B dense) |
 | **Mistral Small 3.2** | 128k | Apache 2.0 | Low-latency, cost-sensitive applications (24B) |
-| **Mistral OCR 3** | — | Proprietary | Document parsing, table reconstruction ($2/1k pages) |
+| **Mistral OCR 4** | — | Proprietary | Document parsing with bounding boxes & confidence scores, 170 languages ($4/1k pages) |
 
 ### Open-Weight Models
 
@@ -133,9 +131,12 @@ Mistral AI offers a compelling alternative in the LLM landscape:
 - 🧠 [Voxtral Mini 3B](https://huggingface.co/mistralai/Voxtral-Mini-3B-2507) – Compact speech understanding model (Apache 2.0).
 
 ### Specialized Models
-- 🧠 **Mistral OCR 3** – Advanced document understanding and table reconstruction (API `mistral-ocr-2512`, $2/1k pages).
-- 🧠 [Leanstral](https://huggingface.co/mistralai/Leanstral-2603) – First open-source Lean 4 formal proof agent (119B / 6.5B active, Apache 2.0).
+- 🧠 **[Mistral OCR 4](https://mistral.ai/news/ocr-4/)** – Document intelligence with bounding boxes, block classification, and per-word confidence scores across 170 languages (API `mistral-ocr-4-0`, $4/1k pages, $2 with Batch API).
+- 🧠 [Leanstral 1.5](https://huggingface.co/mistralai/Leanstral-1-5-119B-A6B) – Lean 4 formal proof agent (119B / 6.5B active, Apache 2.0). Saturates miniF2F, solves 587/672 PutnamBench problems.
 - 🧠 **Mistral Moderation 2603** – Content moderation with jailbreaking, dangerous, and criminal detection (3B, API only).
+
+#### Robotics (Robostral)
+- 🧠 [Robostral Navigate](https://mistral.ai/news/robostral-navigate/) – Embodied navigation model (8B) using a single RGB camera for wheeled, legged, and flying robots; 76.6% success rate on unseen R2R-CE environments (proprietary, enterprise access).
 
 ---
 
@@ -175,15 +176,10 @@ High-quality community fine-tunes built on Mistral base models:
 
 ### Community SDKs
 
-- 🌍 [mistral.rs](https://github.com/EricLBuehler/mistral.rs) – Blazingly fast Rust inference with ISQ, LoRA, quantization.
+- 🌍 [mistral.rs](https://github.com/EricLBuehler/mistral.rs) ⭐ 7k+ – Blazingly fast Rust inference with ISQ, LoRA, quantization.
 - 🌍 [mistral-go](https://github.com/Gage-Technologies/mistral-go) – Go client for Mistral AI API.
 - 🌍 [@ai-sdk/mistral](https://www.npmjs.com/package/@ai-sdk/mistral) – Vercel AI SDK provider.
 - 🌍 [@langchain/mistralai](https://www.npmjs.com/package/@langchain/mistralai) – LangChain.js integration.
-
-### Official Libraries
-
-- 🧠 [mistral-common](https://github.com/mistralai/mistral-common) – Official tokenization and pre-processing library.
-- 🧠 [Mistral Vibe](https://github.com/mistralai/mistral-vibe) – Native CLI coding assistant powered by Mistral Medium 3.5, with cloud-async Remote Agents.
 
 ---
 
@@ -191,15 +187,15 @@ High-quality community fine-tunes built on Mistral base models:
 
 ### High-Performance Inference
 
-- 🌍 [vLLM](https://github.com/vllm-project/vllm) ⭐ 83k+ – High-throughput with PagedAttention. Excellent Mistral support.
-- 🌍 [Text Generation Inference](https://github.com/huggingface/text-generation-inference) ⭐ 11k+ – Hugging Face's production inference server.
-- 🌍 [llama.cpp](https://github.com/ggml-org/llama.cpp) ⭐ 117k+ – CPU/GPU inference with GGUF quantization.
+- 🌍 [vLLM](https://github.com/vllm-project/vllm) ⭐ 86k+ – High-throughput with PagedAttention. Excellent Mistral support.
+- 🌍 [Text Generation Inference](https://github.com/huggingface/text-generation-inference) ⭐ 10k+ – Hugging Face's production inference server.
+- 🌍 [llama.cpp](https://github.com/ggml-org/llama.cpp) ⭐ 121k+ – CPU/GPU inference with GGUF quantization.
 - 🌍 [ExLlamaV2](https://github.com/turboderp/exllamav2) – Fast inference with EXL2 quantization.
-- 🌍 [SGLang](https://github.com/sgl-project/sglang) ⭐ 29k+ – Fast serving with RadixAttention.
+- 🌍 [SGLang](https://github.com/sgl-project/sglang) ⭐ 30k+ – Fast serving with RadixAttention.
 
 ### Local Inference
 
-- 🌍 [Ollama](https://ollama.com) ⭐ 174k+ – Simple CLI for local Mistral models.
+- 🌍 [Ollama](https://ollama.com) ⭐ 176k+ – Simple CLI for local Mistral models.
 - 🌍 [LM Studio](https://lmstudio.ai) – Desktop GUI for local LLMs.
 - 🌍 [Jan](https://jan.ai) – Open-source ChatGPT alternative running locally.
 - 🌍 [GPT4All](https://gpt4all.io) – Local inference with Mistral support.
@@ -208,9 +204,9 @@ High-quality community fine-tunes built on Mistral base models:
 ### Cloud & Container Deployment
 
 - 🌍 [LocalAI](https://github.com/mudler/LocalAI) ⭐ 47k+ – OpenAI-compatible local API server.
-- 🌍 [SkyPilot](https://github.com/skypilot-org/skypilot) – Run on any cloud with cost optimization.
-- 🌍 [MLC LLM](https://github.com/mlc-ai/mlc-llm) – Universal deployment (iOS/Android) perfect for Ministral 3B.
-- 🧠 [TensorRT-LLM](https://github.com/NVIDIA/TensorRT-LLM) – Optimized inference for Mistral Large 3 on NVIDIA GPUs.
+- 🌍 [SkyPilot](https://github.com/skypilot-org/skypilot) ⭐ 10k+ – Run on any cloud with cost optimization.
+- 🌍 [MLC LLM](https://github.com/mlc-ai/mlc-llm) ⭐ 22k+ – Universal deployment (iOS/Android) perfect for Ministral 3B.
+- 🧠 [TensorRT-LLM](https://github.com/NVIDIA/TensorRT-LLM) ⭐ 14k+ – Optimized inference for Mistral Large 3 on NVIDIA GPUs.
 
 ---
 
@@ -218,12 +214,12 @@ High-quality community fine-tunes built on Mistral base models:
 
 ### Fine-Tuning Frameworks
 
-- 🧠 [mistral-finetune](https://github.com/mistralai/mistral-finetune) – Official LoRA fine-tuning library.
-- 🌍 [Axolotl](https://github.com/axolotl-ai-cloud/axolotl) – Streamlined LoRA/QLoRA/full fine-tuning.
-- 🌍 [Unsloth](https://github.com/unslothai/unsloth) ⭐ 67k+ – 2-5x faster fine-tuning, 80% less memory.
+- 🧠 [mistral-finetune](https://github.com/mistralai/mistral-finetune) – ⚠️ Archived, no longer maintained.
+- 🌍 [Axolotl](https://github.com/axolotl-ai-cloud/axolotl) ⭐ 12k+ – Streamlined LoRA/QLoRA/full fine-tuning.
+- 🌍 [Unsloth](https://github.com/unslothai/unsloth) ⭐ 68k+ – 2-5x faster fine-tuning, 80% less memory.
 - 🌍 [Hugging Face PEFT](https://github.com/huggingface/peft) – Parameter-Efficient Fine-Tuning.
 - 🌍 [Hugging Face TRL](https://github.com/huggingface/trl) – RLHF and DPO training.
-- 🌍 [LLaMA-Factory](https://github.com/hiyouga/LLaMA-Factory) ⭐ 72k+ – Unified fine-tuning framework.
+- 🌍 [LLaMA-Factory](https://github.com/hiyouga/LLaMA-Factory) ⭐ 73k+ – Unified fine-tuning framework.
 - 🌍 [torchtune](https://github.com/pytorch/torchtune) – PyTorch-native fine-tuning.
 
 ### Training Infrastructure
@@ -254,19 +250,20 @@ High-quality community fine-tunes built on Mistral base models:
 
 ### Agent Frameworks
 
-- 🌍 [LangChain](https://github.com/langchain-ai/langchain) ⭐ 140k+ – LLM app framework with native Mistral support.
-- 🌍 [LlamaIndex](https://github.com/run-llama/llama_index) ⭐ 50k+ – Data framework for RAG with Mistral.
-- 🌍 [CrewAI](https://github.com/crewAIInc/crewAI) ⭐ 54k+ – Multi-agent orchestration.
+- 🌍 [LangChain](https://github.com/langchain-ai/langchain) ⭐ 142k+ – LLM app framework with native Mistral support.
+- 🌍 [LlamaIndex](https://github.com/run-llama/llama_index) ⭐ 51k+ – Data framework for RAG with Mistral.
+- 🌍 [CrewAI](https://github.com/crewAIInc/crewAI) ⭐ 56k+ – Multi-agent orchestration.
 - 🌍 [AutoGen](https://github.com/microsoft/autogen) ⭐ 59k+ – Microsoft's multi-agent framework.
 - 🌍 [Semantic Kernel](https://github.com/microsoft/semantic-kernel) – Microsoft's AI orchestration SDK.
 - 🌍 [Haystack](https://github.com/deepset-ai/haystack) – End-to-end NLP framework.
 - 🌍 [PydanticAI](https://github.com/pydantic/pydantic-ai) – Type-safe AI agent framework.
+- 🌍 [RocketRide](https://github.com/rocketride-org/rocketride-server) ⭐ 5k+ – C++ AI pipeline engine with dedicated Mistral text/vision nodes, Python/TypeScript SDKs, and a visual IDE.
 
 ### Function Calling & Structured Output
 
 - 🧠 [Mistral Function Calling](https://docs.mistral.ai/capabilities/function_calling/) – Native function calling docs.
 - 🌍 [Instructor](https://github.com/567-labs/instructor) ⭐ 13k+ – Structured outputs with Pydantic.
-- 🌍 [Outlines](https://github.com/dottxt-ai/outlines) ⭐ 14k+ – Guaranteed structured generation.
+- 🌍 [Outlines](https://github.com/dottxt-ai/outlines) ⭐ 15k+ – Guaranteed structured generation.
 - 🌍 [Marvin](https://github.com/prefecthq/marvin) – AI functions with type hints.
 
 ---
@@ -277,17 +274,17 @@ High-quality community fine-tunes built on Mistral base models:
 
 - 🧠 [Mistral Code](https://mistral.ai/news/mistral-code) – Official AI coding assistant (VS Code/JetBrains) built on the Mistral coding stack.
 - 🧠 [Zed Extensions](https://github.com/mistralai/zed-extensions) – Official Mistral for Zed editor.
-- 🌍 [Continue](https://github.com/continuedev/continue) ⭐ 34k+ – Open-source AI code assistant (VSCode/JetBrains).
-- 🌍 [Tabby](https://github.com/TabbyML/tabby) ⭐ 34k+ – Self-hosted GitHub Copilot alternative.
-- 🌍 [Aider](https://github.com/Aider-AI/aider) ⭐ 46k+ – AI pair programming in terminal.
+- 🌍 [Continue](https://github.com/continuedev/continue) ⭐ 35k+ – Open-source AI code assistant (VSCode/JetBrains).
+- 🌍 [Tabby](https://github.com/TabbyML/tabby) ⭐ 33k+ – Self-hosted GitHub Copilot alternative.
+- 🌍 [Aider](https://github.com/Aider-AI/aider) ⭐ 47k+ – AI pair programming in terminal.
 - 🌍 [Cody](https://sourcegraph.com/cody) – AI coding assistant with codebase context.
 
 ### Development Tools
 
-- 🌍 [LiteLLM](https://github.com/BerriAI/litellm) ⭐ 51k+ – Unified API for 100+ LLMs.
-- 🌍 [Promptfoo](https://github.com/promptfoo/promptfoo) ⭐ 22k+ – LLM evaluation and red-teaming.
-- 🌍 [Langfuse](https://github.com/langfuse/langfuse) ⭐ 29k+ – Open-source LLM observability.
-- 🌍 [Phoenix](https://github.com/Arize-ai/phoenix) – ML observability for LLM apps.
+- 🌍 [LiteLLM](https://github.com/BerriAI/litellm) ⭐ 54k+ – Unified API for 100+ LLMs.
+- 🌍 [Promptfoo](https://github.com/promptfoo/promptfoo) ⭐ 23k+ – LLM evaluation and red-teaming.
+- 🌍 [Langfuse](https://github.com/langfuse/langfuse) ⭐ 31k+ – Open-source LLM observability.
+- 🌍 [Phoenix](https://github.com/Arize-ai/phoenix) ⭐ 10k+ – ML observability for LLM apps.
 - 🌍 [Weights & Biases](https://wandb.ai) – Experiment tracking with LLM support.
 
 ---
@@ -296,25 +293,25 @@ High-quality community fine-tunes built on Mistral base models:
 
 ### Chat Interfaces
 
-- 🌍 [Open WebUI](https://github.com/open-webui/open-webui) ⭐ 142k+ – Self-hosted ChatGPT-like UI.
-- 🌍 [LibreChat](https://github.com/danny-avila/LibreChat) ⭐ 39k+ – Multi-model chat interface.
-- 🌍 [Lobe Chat](https://github.com/lobehub/lobe-chat) ⭐ 78k+ – Modern extensible chat framework.
+- 🌍 [Open WebUI](https://github.com/open-webui/open-webui) ⭐ 146k+ – Self-hosted ChatGPT-like UI.
+- 🌍 [LibreChat](https://github.com/danny-avila/LibreChat) ⭐ 41k+ – Multi-model chat interface.
+- 🌍 [Lobe Chat](https://github.com/lobehub/lobe-chat) ⭐ 80k+ – Modern extensible chat framework.
 - 🌍 [Chatbot UI](https://github.com/mckaywrigley/chatbot-ui) – Open-source ChatGPT clone.
 - 🌍 [BetterChatGPT](https://github.com/ztjhz/BetterChatGPT) – Enhanced chat interface.
 
 ### RAG & Knowledge Management
 
 - 🌍 [PrivateGPT](https://github.com/zylon-ai/private-gpt) ⭐ 57k+ – Private document Q&A.
-- 🌍 [Onyx](https://github.com/onyx-dot-app/onyx) ⭐ 30k+ – Enterprise Q&A over internal docs (formerly Danswer).
+- 🌍 [Onyx](https://github.com/onyx-dot-app/onyx) ⭐ 31k+ – Enterprise Q&A over internal docs (formerly Danswer).
 - 🌍 [Quivr](https://github.com/QuivrHQ/quivr) ⭐ 39k+ – Personal knowledge base.
 - 🌍 [Khoj](https://github.com/khoj-ai/khoj) – AI second brain.
 - 🌍 [LocalGPT](https://github.com/PromtEngineer/localGPT) – Chat with documents locally.
 
 ### Specialized Applications
 
-- 🌍 [Fabric](https://github.com/danielmiessler/fabric) ⭐ 42k+ – AI augmentation framework.
+- 🌍 [Fabric](https://github.com/danielmiessler/fabric) ⭐ 43k+ – AI augmentation framework.
 - 🌍 [GPT Researcher](https://github.com/assafelovic/gpt-researcher) ⭐ 28k+ – Autonomous research agent.
-- 🌍 [OpenHands](https://github.com/OpenHands/OpenHands) ⭐ 78k+ – AI software engineer (formerly OpenDevin).
+- 🌍 [OpenHands](https://github.com/OpenHands/OpenHands) ⭐ 81k+ – AI software engineer (formerly OpenDevin).
 
 ---
 
@@ -386,10 +383,12 @@ High-quality community fine-tunes built on Mistral base models:
 - 🧠 [Mixtral of Experts](https://arxiv.org/abs/2401.04088) – Sparse MoE architecture.
 - 🧠 [Introducing Mistral 3](https://mistral.ai/news/mistral-3/) – Mistral Large 3 / Ministral 3 family announcement and benchmarks.
 - 🧠 [Mistral Small 4 Blog](https://mistral.ai/news/mistral-small-4) – Hybrid MoE architecture announcement.
-- 🧠 [Leanstral Blog](https://mistral.ai/news/leanstral) – First open-source Lean 4 formal proof agent.
+- 🧠 [Leanstral 1.5 Blog](https://mistral.ai/news/leanstral-1-5/) – Lean 4 formal proof agent update.
 - 🧠 [Forge Announcement](https://mistral.ai/news/forge) – Enterprise model training platform.
 - 🧠 [Voxtral Blog](https://mistral.ai/news/voxtral/) – Real-time speech-to-text models.
 - 🧠 [Voxtral Mini Technical Report](https://arxiv.org/abs/2602.11298) – Voxtral Mini 4B Realtime architecture paper.
+- 🧠 [Mistral OCR 4 Blog](https://mistral.ai/news/ocr-4/) – Document intelligence model announcement.
+- 🧠 [Robostral Navigate Blog](https://mistral.ai/news/robostral-navigate/) – First embodied-AI navigation model.
 
 ### Related Research
 
@@ -406,7 +405,6 @@ High-quality community fine-tunes built on Mistral base models:
 ### Official Channels
 
 - 🧠 [Mistral AI Blog](https://mistral.ai/news/) – Official announcements.
-- 🧠 [Vibe](https://chat.mistral.ai) – Official unified work & coding agent (formerly le Chat).
 - 🧠 [Mistral AI Discord](https://discord.gg/mistralai) – Official community server.
 - 🧠 [Mistral AI Twitter/X](https://twitter.com/MistralAI) – Official updates.
 
@@ -437,11 +435,8 @@ High-quality community fine-tunes built on Mistral base models:
 
 ### Partnerships
 
-- 🧠 [Microsoft Azure Partnership](https://azure.microsoft.com/en-us/blog/microsoft-and-mistral-ai-announce-new-partnership-to-accelerate-ai-innovation-and-introduce-mistral-large-first-on-azure/) – Strategic Azure partnership.
-- 🧠 [NVIDIA Nemotron Coalition](https://mistral.ai/news/mistral-small-4) – Founding member of NVIDIA's AI collaboration initiative.
-- 🧠 [AI Studio (la Plateforme)](https://console.mistral.ai/) – Mistral’s developer and enterprise cloud platform.
-- 🧠 [Mistral Forge](https://mistral.ai/news/forge) – Enterprise model training on proprietary data.
-- 🧠 [Mistral Compute](https://mistral.ai/products/compute) – European-hosted GPU cloud infrastructure.
+- 🧠 [Microsoft Strategic Partnership](https://news.microsoft.com/source/2026/07/21/microsoft-and-mistral-expand-strategic-partnership-to-give-enterprises-and-regulated-industries-frontier-ai-they-can-control/) – Multibillion-dollar European AI infrastructure deal; Mistral Medium 3.5 and OCR 4 available in Microsoft Foundry and Copilot Studio.
+- 🧠 [NVIDIA Nemotron Coalition](https://mistral.ai/news/mistral-ai-and-nvidia-partner-to-accelerate-open-frontier-models/) – Founding member of NVIDIA's open frontier model coalition, co-developing open-source models.
 
 ---
 
@@ -454,7 +449,7 @@ Contributions are welcome! Please read the [contribution guidelines](CONTRIBUTIN
 1. Ensure all links point to real, existing resources
 2. Use consistent formatting: `- 🧠/🌍/🧪 [Name](url) – Brief description.`
 3. Prefer high-signal, actively maintained projects
-4. Include star counts for major projects (⭐ 10k+)
+4. Include star counts for major projects (⭐ 5k+)
 
 ---
 


### PR DESCRIPTION
## Summary

Monthly maintenance update, verified against official sources (mistral.ai, Microsoft, GitHub) — not just aggregated from search results.

**New July 2026 releases** (all confirmed via mistral.ai/news or the partner's own announcement):
- Mistral OCR 4 (Jun 23) — 170-language document intelligence
- Connector admin controls (Jun 24)
- Leanstral 1.5 (Jul 2) — Apache 2.0, 100% miniF2F, 587/672 PutnamBench
- Robostral Navigate (Jul 8) — Mistral's first embodied-AI model
- Studio Prompts & Skills versioning (Jul 9)
- Expanded Microsoft strategic partnership (Jul 21) — multibillion-dollar EU compute deal

**Bugs fixed:**
- `mistral-inference` and `mistral-finetune` are both archived upstream — flagged with pointers to active alternatives (vLLM/mistral.rs, Axolotl/Unsloth/TRL)
- The "NVIDIA Nemotron Coalition" link pointed to the wrong blog post (Mistral Small 4 announcement) — corrected to the actual coalition announcement
- Removed duplicate entries: mistral-common, Mistral Vibe (GitHub repo), Mistral Forge, Mistral Compute, and the Vibe/Azure partnership listings were each appearing 2-3 times across sections

**Additions:**
- RocketRide (Agents & Orchestration) — verified 5.4k GitHub stars, MIT license, dedicated Mistral text/vision integration nodes

**Refreshed:** star counts across ~30 existing entries, plus new star badges for repos that crossed the 5k threshold since the June refresh (mistral.rs, Phoenix, SkyPilot, MLC LLM, TensorRT-LLM, Axolotl). Also aligned the README's own "Quick Guidelines" star threshold (previously said 10k+) with CONTRIBUTING.md's stated 5k+ rule.

## Test plan
- [x] Verified every new claim against an official source (mistral.ai blog, Microsoft newsroom, or live GitHub API) before including it
- [x] Confirmed archived status of mistral-inference/mistral-finetune directly on GitHub
- [x] Re-checked TOC anchors resolve correctly after the What's New header rename
- [x] Spot-checked ~40 star counts via `gh api` immediately before writing them