### PR TITLE
Add Aeon under Agent Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,10 +255,10 @@ High-quality community fine-tunes built on Mistral base models:
 - 🌍 [CrewAI](https://github.com/crewAIInc/crewAI) ⭐ 56k+ – Multi-agent orchestration.
 - 🌍 [AutoGen](https://github.com/microsoft/autogen) ⭐ 59k+ – Microsoft's multi-agent framework.
 - 🌍 [Semantic Kernel](https://github.com/microsoft/semantic-kernel) – Microsoft's AI orchestration SDK.
+- 🌍 [Aeon](https://github.com/aeonfun/aeon) – Autonomous agent framework that runs unattended on GitHub Actions and drives Mistral Vibe as one of six coding-agent harnesses behind a single contract, with quality scoring, persistent memory, and a self-healing loop.
 - 🌍 [Haystack](https://github.com/deepset-ai/haystack) – End-to-end NLP framework.
 - 🌍 [PydanticAI](https://github.com/pydantic/pydantic-ai) – Type-safe AI agent framework.
 - 🌍 [RocketRide](https://github.com/rocketride-org/rocketride-server) ⭐ 5k+ – C++ AI pipeline engine with dedicated Mistral text/vision nodes, Python/TypeScript SDKs, and a visual IDE.
-- 🌍 [Aeon](https://github.com/aeonfun/aeon) ⭐ 588 – Autonomous agent framework that runs unattended on GitHub Actions and drives Mistral Vibe as one of six coding-agent harnesses behind a single contract, with quality scoring, persistent memory, and a self-healing loop.
 
 ### Function Calling & Structured Output
 

--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ High-quality community fine-tunes built on Mistral base models:
 - 🌍 [Haystack](https://github.com/deepset-ai/haystack) – End-to-end NLP framework.
 - 🌍 [PydanticAI](https://github.com/pydantic/pydantic-ai) – Type-safe AI agent framework.
 - 🌍 [RocketRide](https://github.com/rocketride-org/rocketride-server) ⭐ 5k+ – C++ AI pipeline engine with dedicated Mistral text/vision nodes, Python/TypeScript SDKs, and a visual IDE.
+- 🌍 [Aeon](https://github.com/aeonfun/aeon) ⭐ 588 – Autonomous agent framework that runs unattended on GitHub Actions and drives Mistral Vibe as one of six coding-agent harnesses behind a single contract, with quality scoring, persistent memory, and a self-healing loop.
 
 ### Function Calling & Structured Output
 


### PR DESCRIPTION
Adds **Aeon** under **Agents & Orchestration -> Agent Frameworks**.

Aeon is an autonomous agent framework that runs unattended on GitHub Actions and can drive **Mistral Vibe** as one of six coding-agent harnesses behind a single contract. Formatted with the community tag and star count per the list conventions.

---
Aeon: https://github.com/aeonfun/aeon (MIT, ~588 stars, actively maintained). Disclosure: I work on Aeon. Single entry; happy to adjust wording or placement to fit the list's conventions.
